### PR TITLE
Adding test support for arm64

### DIFF
--- a/hack/generate-yaml.sh
+++ b/hack/generate-yaml.sh
@@ -59,13 +59,15 @@ case $LOCAL_OS in
     ;;
 esac
 
+ARCH=$(go env GOARCH)
+
 # Step1. install helm binary
 if [[ ! -f "${HELM_BIN_DIR}/version.helm.${HELM_VER}" ]] ; then
     TD=$(mktemp -d)
     cd "${TD}" && \
-        curl -Lo "${TD}/helm.tgz" "https://get.helm.sh/helm-${HELM_VER}-${LOCAL_OS}-amd64.tar.gz" && \
+        curl -Lo "${TD}/helm.tgz" "https://get.helm.sh/helm-${HELM_VER}-${LOCAL_OS}-${ARCH}.tar.gz" && \
         tar xfz helm.tgz && \
-        mv ${LOCAL_OS}-amd64/helm "${HELM_BIN_DIR}/helm-${HELM_VER}" && \
+        mv ${LOCAL_OS}-${ARCH}/helm "${HELM_BIN_DIR}/helm-${HELM_VER}" && \
         cp "${HELM_BIN_DIR}/helm-${HELM_VER}" "${HELM_BIN_DIR}/helm" && \
         chmod +x ${HELM_BIN_DIR}/helm
         rm -rf "${TD}" && \

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -72,9 +72,9 @@ const (
 )
 
 const (
-	DefaultBusyBoxImage = "busybox:1.24"
-	DefaultNginxImage   = "nginx:1.14"
-	DefaultMPIImage     = "volcanosh/example-mpi:0.0.1"
+	DefaultBusyBoxImage = "busybox:latest"
+	DefaultNginxImage   = "nginx:latest"
+	DefaultMPIImage     = "9490808583/example-mpi:latest"
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
 )
 


### PR DESCRIPTION
Hi

**Package Owner**: Anil Reddy
**PR change Details**:
**Patch Details**: Following file has been modified:
Modified files volcano/test/e2e/util/util.go and volcano/hack/generate-yaml.sh for running the test for arm64 platform.
**PR Description**: Here is my commit message:
Adding test support for arm64
**PR Description**:
The following file has been modified:
Modified files volcano/test/e2e/util/util.go and volcano/hack/generate-yaml.sh for running the test for arm64 platform.

**Reviewer**: Disha Srivastava, Akhand pratap
Thanks
Anil Reddy
**Signed-off-by**: odidev@puresoftware.com